### PR TITLE
Added list Animation and changed sticky header style

### DIFF
--- a/feature/currencyunits/src/main/java/org/expenny/feature/currencyunits/CurrencyUnitsListContract.kt
+++ b/feature/currencyunits/src/main/java/org/expenny/feature/currencyunits/CurrencyUnitsListContract.kt
@@ -15,10 +15,10 @@ data class State(
 sealed interface Action {
     class OnCurrencyUnitSelect(val id: Long) : Action
     class OnSearchQueryChange(val query: String) : Action
-    object OnCloseClick : Action
+    data object OnCloseClick : Action
 }
 
 sealed interface Event {
     class NavigateBackWithResult(val result: LongNavArg) : Event
-    object NavigateBack : Event
+    data object NavigateBack : Event
 }

--- a/feature/currencyunits/src/main/java/org/expenny/feature/currencyunits/view/CurrencyUnitsList.kt
+++ b/feature/currencyunits/src/main/java/org/expenny/feature/currencyunits/view/CurrencyUnitsList.kt
@@ -1,20 +1,30 @@
 package org.expenny.feature.currencyunits.view
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalMinimumInteractiveComponentEnforcement
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.expenny.core.ui.data.selection.SingleSelection
 import org.expenny.core.ui.data.ui.CurrencyUnitUi
@@ -22,6 +32,7 @@ import org.expenny.core.ui.foundation.ExpennyCard
 import org.expenny.core.ui.foundation.ExpennyGroupedVerticalList
 import java.util.SortedMap
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun CurrencyUnitsList(
     modifier: Modifier = Modifier,
@@ -34,27 +45,59 @@ internal fun CurrencyUnitsList(
         groupedList = currencyUnits,
         listItemKey = CurrencyUnitUi::code,
         listItemHeader = { header ->
-            Text(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(MaterialTheme.colorScheme.surface),
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                style = MaterialTheme.typography.labelLarge,
+            CurrencyItemHeader(
                 text = header,
+                modifier = Modifier
+                    .background(MaterialTheme.colorScheme.surface)
+                    .fillMaxWidth()
+                    .animateItemPlacement()
             )
         },
         listItem = { item ->
             CurrencyUnitItem(
-                modifier = Modifier.fillMaxWidth(),
                 isSelected = selection.contains(item.id),
                 code = item.code,
                 name = item.name,
-                onClick = {
-                    onCurrencyUnitClick(item.id)
-                }
+                onClick = { onCurrencyUnitClick(item.id) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .animateItemPlacement(),
             )
         }
     )
+}
+
+
+@Composable
+private fun CurrencyItemHeader(
+    text: String,
+    modifier: Modifier = Modifier,
+    boxShape: Shape = MaterialTheme.shapes.small,
+    border: BorderStroke = BorderStroke(2.dp, MaterialTheme.colorScheme.outline),
+    backGroundColor: Color = MaterialTheme.colorScheme.surfaceVariant,
+    contentColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+    textStyle: TextStyle = MaterialTheme.typography.labelLarge
+) {
+    Box(
+        modifier = modifier.padding(vertical = 8.dp),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Box(
+            modifier = Modifier
+                .wrapContentWidth()
+                .background(color = backGroundColor, shape = boxShape)
+                .border(border = border, shape = boxShape),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = text,
+                color = contentColor,
+                style = textStyle,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+        }
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)


### PR DESCRIPTION
These are the changes included in this pull request.
- Added a new sticky header to the currency unit list , The new one seems a bit  bold and eye catching.
-  Used `Modifier.animateItemPlacement()` in the LazyColumn Scope to add animation when the list changes i.e., during the search results are shown